### PR TITLE
Fix: Session length slider issue in SettingsScreen. 

### DIFF
--- a/app/src/main/java/org/nsh07/pomodoro/ui/settingsScreen/viewModel/SettingsViewModel.kt
+++ b/app/src/main/java/org/nsh07/pomodoro/ui/settingsScreen/viewModel/SettingsViewModel.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.launch
 import org.nsh07.pomodoro.TomatoApplication
 import org.nsh07.pomodoro.data.AppPreferenceRepository
 import org.nsh07.pomodoro.data.TimerRepository
-import org.nsh07.pomodoro.ui.timerScreen.viewModel.TimerState
 
 @OptIn(FlowPreview::class, ExperimentalMaterial3Api::class)
 class SettingsViewModel(


### PR DESCRIPTION
## Description 

This pull request introduces a fix for #55, where the session length slider in the Settings screen was experiencing a race condition where it would initialize with an incorrect value. The slider was being initialized with timerRepository.sessionLength before the TimerViewModel had a chance to update the repository, causing the slider to display stale or default values instead of the user's saved preferences.


## Recording
|BEFORE | AFTER |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/6c139f28-cfcc-4efb-8512-853ce7ddc84d">|<video src="https://github.com/user-attachments/assets/77e2022d-2a6a-4fa3-be7e-af0d3106cd88">|









