### PR TITLE
Remove unnecessary Long-to-Int cast in toggleTimer() (fixes #121)

### DIFF
--- a/app/src/main/java/org/nsh07/pomodoro/service/TimerService.kt
+++ b/app/src/main/java/org/nsh07/pomodoro/service/TimerService.kt
@@ -168,11 +168,11 @@ class TimerService : Service() {
                     if (startTime == 0L) startTime = SystemClock.elapsedRealtime()
 
                     time = when (timerState.value.timerMode) {
-                        TimerMode.FOCUS -> timerRepository.focusTime - (SystemClock.elapsedRealtime() - startTime - pauseDuration).toInt()
+                        TimerMode.FOCUS -> timerRepository.focusTime - (SystemClock.elapsedRealtime() - startTime - pauseDuration)
 
-                        TimerMode.SHORT_BREAK -> timerRepository.shortBreakTime - (SystemClock.elapsedRealtime() - startTime - pauseDuration).toInt()
+                        TimerMode.SHORT_BREAK -> timerRepository.shortBreakTime - (SystemClock.elapsedRealtime() - startTime - pauseDuration)
 
-                        else -> timerRepository.longBreakTime - (SystemClock.elapsedRealtime() - startTime - pauseDuration).toInt()
+                        else -> timerRepository.longBreakTime - (SystemClock.elapsedRealtime() - startTime - pauseDuration)
                     }
 
                     iterations =


### PR DESCRIPTION
### Description: 
Removing unnecessary type conversion in `TimerService.kt` file

### Changes:
Minimal changes. Just removed redundant `.toInt()` cast in timer calculations inside `toggleTimer()` method of `TimerService.kt`.

**No changes in functionality** or in any other file etc was done.
