### PR TITLE
Fix: ensuring room DB instance is created only once by double-checked locking

### DIFF
--- a/app/src/main/java/org/nsh07/pomodoro/data/AppDatabase.kt
+++ b/app/src/main/java/org/nsh07/pomodoro/data/AppDatabase.kt
@@ -17,7 +17,9 @@ import androidx.room.TypeConverters
 @Database(
     entities = [IntPreference::class, BooleanPreference::class, StringPreference::class, Stat::class],
     version = 2,
-    autoMigrations = [AutoMigration(from = 1, to = 2)]
+    autoMigrations = [
+        AutoMigration(from = 1, to = 2)
+    ]
 )
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
@@ -33,7 +35,8 @@ abstract class AppDatabase : RoomDatabase() {
         fun getDatabase(context: Context): AppDatabase {
             return Instance ?: synchronized(this) {
                 Instance ?: Room.databaseBuilder(context, AppDatabase::class.java, "app_database")
-                    .build().also { Instance = it }
+                    .build()
+                    .also { Instance = it }
             }
         }
     }


### PR DESCRIPTION
- Ensures Room DB initialization happens only once by implementing double-checked locking
- Only file that's changed is  `AppDatabase.kt`
- fixes #130