### PR TITLE
Fix/align focus text

### DIFF
--- a/app/src/main/java/org/nsh07/pomodoro/ui/timerScreen/TimerScreen.kt
+++ b/app/src/main/java/org/nsh07/pomodoro/ui/timerScreen/TimerScreen.kt
@@ -154,6 +154,7 @@ fun SharedTransitionScope.TimerScreen(
                         )
                     },
                     contentAlignment = Alignment.Center,
+                    modifier = Modifier.fillMaxWidth(.9f)
                 ) {
                     when (it) {
                         TimerMode.BRAND ->


### PR DESCRIPTION
Based on #123 

Apparently `TopAppBar` have slight padding on the right. `Alignment.Center` is enough to center the text, no need for `fillMaxWidth()`