### PR TITLE
Fix: Weekly view missing days and Today's focus not appearing in graph

### DIFF
--- a/app/src/main/java/org/nsh07/pomodoro/ui/statsScreen/viewModel/StatsViewModel.kt
+++ b/app/src/main/java/org/nsh07/pomodoro/ui/statsScreen/viewModel/StatsViewModel.kt
@@ -81,7 +81,7 @@ class StatsViewModel(
 
     private val yearDayFormatter = DateTimeFormatter.ofPattern("d MMM")
 
-    private val lastWeekStatsFlow = statRepository.getLastNDaysStats(7).filter { it.isNotEmpty() }
+    private val lastWeekStatsFlow = statRepository.getLastNDaysStats(7)
     private val lastMonthStatsFlow = statRepository.getLastNDaysStats(31).filter { it.isNotEmpty() }
     private val lastYearStatsFlow = statRepository.getLastNDaysStats(365).filter { it.isNotEmpty() }
 
@@ -91,15 +91,17 @@ class StatsViewModel(
     val lastWeekMainChartData: StateFlow<Pair<CartesianChartModelProducer, ExtraStore.Key<List<String>>>> =
         lastWeekStatsFlow
             .map { list ->
-                // reversing is required because we need ascending order while the DB returns descending order
-                val reversed = list.reversed()
-                val keys = reversed.map {
-                    it.date.dayOfWeek.getDisplayName(
+                val today = LocalDate.now()
+                val last7Days = (0..6).map { today.minusDays(it.toLong()) }.reversed()
+                val statsMap = list.associateBy { it.date }
+
+                val keys = last7Days.map {
+                    it.dayOfWeek.getDisplayName(
                         TextStyle.NARROW,
                         Locale.getDefault()
                     )
                 }
-                val values = reversed.map { it.totalFocusTime() }
+                val values = last7Days.map { statsMap[it]?.totalFocusTime() ?: 0L }
                 lastWeekSummary.first.runTransaction {
                     columnSeries { series(values) }
                     extras { it[lastWeekSummary.second] = keys }
@@ -115,18 +117,23 @@ class StatsViewModel(
 
     val lastWeekFocusHistoryValues: StateFlow<List<Pair<String, List<Long>>>> =
         lastWeekStatsFlow
-            .map { value ->
-                value.reversed().map {
+            .map { list ->
+                val today = LocalDate.now()
+                val last7Days = (0..6).map { today.minusDays(it.toLong()) }.reversed()
+                val statsMap = list.associateBy { it.date }
+
+                last7Days.map { date ->
+                    val stat = statsMap[date]
                     Pair(
-                        it.date.dayOfWeek.getDisplayName(
+                        date.dayOfWeek.getDisplayName(
                             TextStyle.NARROW,
                             Locale.getDefault()
                         ),
                         listOf(
-                            it.focusTimeQ1,
-                            it.focusTimeQ2,
-                            it.focusTimeQ3,
-                            it.focusTimeQ4
+                            stat?.focusTimeQ1 ?: 0L,
+                            stat?.focusTimeQ2 ?: 0L,
+                            stat?.focusTimeQ3 ?: 0L,
+                            stat?.focusTimeQ4 ?: 0L
                         )
                     )
                 }


### PR DESCRIPTION
### Issue
In the **Weekly Stats** view, the graph was not displaying all days correctly, as reported in **#201**.  
Thursday and Friday were missing, and after Wednesday the graph jumped directly to Saturday/Sunday.  
Additionally, **today’s focus time** was visible elsewhere in the UI but did not appear in the weekly graph.

---

### Cause
The weekly graph logic relied directly on the result of `getLastNDaysStats(7)`, which returns **only the days that have recorded data**.  
If focus time was not recorded on certain days, those days were excluded from the result, causing gaps in the graph.

Additionally, `lastWeekStatsFlow` used `.filter { it.isNotEmpty() }`, which prevented the graph from rendering when data was sparse or partially missing.

---

### Fix
The stats calculation was updated to ensure a **consistent 7-day display**:

- Generated an explicit **7-day date range** (today − 6 days to today).
- Mapped database results to this fixed date range, filling missing days with `0` focus time.
- Removed the `.filter { it.isNotEmpty() }` condition so the graph updates even when some days have no data.

---

### Result
- The weekly graph now always shows **all 7 days** without skipping any.
- Days with no focus time correctly display `0`.
- **Today’s focus time** reliably appears in the weekly graph.
