### PR TITLE
fix(settings): make timer settings switch rows clickable

### DIFF
--- a/shared/src/commonMain/kotlin/org/nsh07/pomodoro/ui/settingsScreen/screens/TimerSettings.kt
+++ b/shared/src/commonMain/kotlin/org/nsh07/pomodoro/ui/settingsScreen/screens/TimerSettings.kt
@@ -50,6 +50,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.SegmentedListItem
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.MaterialTheme.motionScheme
@@ -98,6 +99,7 @@ import org.nsh07.pomodoro.ui.theme.TomatoShapeDefaults.PANE_MAX_WIDTH
 import org.nsh07.pomodoro.ui.theme.TomatoShapeDefaults.bottomListItemShape
 import org.nsh07.pomodoro.ui.theme.TomatoShapeDefaults.cardShape
 import org.nsh07.pomodoro.ui.theme.TomatoShapeDefaults.middleListItemShape
+import org.nsh07.pomodoro.ui.theme.TomatoShapeDefaults.segmentedListItemShapes
 import org.nsh07.pomodoro.ui.theme.TomatoShapeDefaults.topListItemShape
 import org.nsh07.pomodoro.utils.androidSdkVersionAtLeast
 import org.nsh07.pomodoro.utils.millisecondsToHoursMinutes
@@ -410,7 +412,8 @@ fun TimerSettings(
                 item { Spacer(Modifier.height(12.dp)) }
 
                 itemsIndexed(switchItems[0]) { index, item ->
-                    ListItem(
+                    SegmentedListItem(
+                        onClick = { item.onClick(!item.checked) },
                         leadingContent = {
                             Icon(
                                 painterResource(item.icon),
@@ -418,7 +421,7 @@ fun TimerSettings(
                                 modifier = Modifier.padding(top = 4.dp)
                             )
                         },
-                        headlineContent = { Text(stringResource(item.label)) },
+                        content = { Text(stringResource(item.label)) },
                         supportingContent = { Text(stringResource(item.description)) },
                         trailingContent = {
                             Switch(
@@ -444,20 +447,15 @@ fun TimerSettings(
                             )
                         },
                         colors = listItemColors,
-                        modifier = Modifier.clip(
-                            when (index) {
-                                0 -> topListItemShape
-                                switchItems[0].size - 1 -> bottomListItemShape
-                                else -> middleListItemShape
-                            }
-                        )
+                        shapes = segmentedListItemShapes(index, switchItems[0].size)
                     )
                 }
 
                 if (isPlus) {
                     item { Spacer(Modifier.height(12.dp)) }
                     itemsIndexed(switchItems[1]) { index, item ->
-                        ListItem(
+                        SegmentedListItem(
+                            onClick = { item.onClick(!item.checked) },
                             leadingContent = {
                                 Icon(
                                     painterResource(item.icon),
@@ -465,7 +463,7 @@ fun TimerSettings(
                                     modifier = Modifier.padding(top = 4.dp)
                                 )
                             },
-                            headlineContent = { Text(stringResource(item.label)) },
+                            content = { Text(stringResource(item.label)) },
                             supportingContent = { Text(stringResource(item.description)) },
                             trailingContent = {
                                 Switch(
@@ -491,13 +489,7 @@ fun TimerSettings(
                                 )
                             },
                             colors = listItemColors,
-                            modifier = Modifier.clip(
-                                when (index) {
-                                    0 -> topListItemShape
-                                    switchItems[1].size - 1 -> bottomListItemShape
-                                    else -> middleListItemShape
-                                }
-                            )
+                            shapes = segmentedListItemShapes(index, switchItems[1].size)
                         )
                     }
                 }
@@ -505,11 +497,18 @@ fun TimerSettings(
                 if (androidSdkVersionAtLeast(36)) {
                     item { Spacer(Modifier.height(12.dp)) }
                     item {
-                        ListItem(
+                        SegmentedListItem(
+                            onClick = {
+                                onAction(
+                                    SettingsAction.SaveSingleProgressBar(
+                                        !settingsState.singleProgressBar
+                                    )
+                                )
+                            },
                             leadingContent = {
                                 Icon(painterResource(Res.drawable.view_day), null)
                             },
-                            headlineContent = { Text(stringResource(Res.string.session_only_progress)) },
+                            content = { Text(stringResource(Res.string.session_only_progress)) },
                             supportingContent = {
                                 var expanded by remember { mutableStateOf(false) }
                                 Text(
@@ -551,7 +550,8 @@ fun TimerSettings(
                                 )
                             },
                             colors = listItemColors,
-                            modifier = Modifier.clip(cardShape)
+                            shapes = segmentedListItemShapes(0, 1),
+                            enabled = !serviceRunning
                         )
                     }
                 }
@@ -561,7 +561,8 @@ fun TimerSettings(
                         PlusDivider(setShowPaywall)
                     }
                     itemsIndexed(switchItems[1]) { index, item ->
-                        ListItem(
+                        SegmentedListItem(
+                            onClick = { item.onClick(!item.checked) },
                             leadingContent = {
                                 Icon(
                                     painterResource(item.icon),
@@ -569,7 +570,7 @@ fun TimerSettings(
                                     modifier = Modifier.padding(top = 4.dp)
                                 )
                             },
-                            headlineContent = { Text(stringResource(item.label)) },
+                            content = { Text(stringResource(item.label)) },
                             supportingContent = { Text(stringResource(item.description)) },
                             trailingContent = {
                                 Switch(
@@ -595,13 +596,7 @@ fun TimerSettings(
                                 )
                             },
                             colors = listItemColors,
-                            modifier = Modifier.clip(
-                                when (index) {
-                                    0 -> topListItemShape
-                                    switchItems[1].size - 1 -> bottomListItemShape
-                                    else -> middleListItemShape
-                                }
-                            )
+                            shapes = segmentedListItemShapes(index, switchItems[1].size)
                         )
                     }
                 }


### PR DESCRIPTION
## Goal
Resolve toggle touch target inconsistencies between the timer settings and alarm settings screens. On the alarm settings page, tapping anywhere on a row container (including the title, description, or background) toggles the switch. This PR refactors the timer settings page switch rows to match this behavior.

## Proposed Changes
Instead of standard `ListItem` rows with manual shape clipping, all switch rows on the timer settings page now use the canonical `SegmentedListItem` component, matching the pattern used in the rest of the settings screens (alarm settings, appearance settings, etc.):

- **`SegmentedListItem` Migration**: Replaced `ListItem` with `SegmentedListItem` in the following switch components within `TimerSettings.kt`:
  - `switchItems[0]` (Auto-start Next Session, Do Not Disturb)
  - `switchItems[1]` (Always On Display, Secure AOD)
  - Single progress bar toggle (Session-only progress bar)
- **Row-wide click targets**: Bound the toggle callback directly to the row container's `onClick` handler (`onClick = { item.onClick(!item.checked) }`).
- **Segmented shape styling**: Cleaned up manual shape clipping modifiers and moved to the built-in `shapes = segmentedListItemShapes(...)` parameter.

## Verification
- Built the application successfully using `./gradlew assembleDebug`.
- Verified code consistency and design alignment with `AlarmSettings.kt` and `AppearanceSettings.kt`.