### PR TITLE
Fix: Doze mode timer, ANR risk, and NPE safety

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -24,6 +24,8 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
 
     <application
         android:name=".TomatoApplication"

--- a/androidApp/src/main/java/org/nsh07/pomodoro/service/TimerService.kt
+++ b/androidApp/src/main/java/org/nsh07/pomodoro/service/TimerService.kt
@@ -27,6 +27,8 @@ import android.media.AudioAttributes
 import android.media.MediaPlayer
 import android.os.Build
 import android.os.IBinder
+import android.app.AlarmManager
+import android.app.PendingIntent
 import android.os.SystemClock
 import android.os.VibrationEffect
 import android.os.Vibrator
@@ -100,6 +102,11 @@ class TimerService : Service(), KoinComponent {
 
     private var autoAlarmStopScope: Job? = null
 
+    private val alarmManager by lazy { getSystemService(ALARM_SERVICE) as AlarmManager }
+    private val alarmIntent by lazy {
+        val intent = Intent(this, TimerService::class.java).apply { action = Actions.WAKE_UP.toString() }
+        PendingIntent.getService(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+    }
     private var alarm: MediaPlayer? = null
     private val vibrator by lazy {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -127,8 +134,8 @@ class TimerService : Service(), KoinComponent {
     override fun onDestroy() {
         stateRepository.timerState.update { it.copy(serviceRunning = false) }
         updateQSTile()
-        runBlocking {
-            job.cancel()
+        job.cancel()
+        CoroutineScope(Dispatchers.IO + kotlinx.coroutines.NonCancellable).launch {
             saveTimeToDb()
             lastSavedDuration = 0
             setDoNotDisturb(false)
@@ -170,6 +177,8 @@ class TimerService : Service(), KoinComponent {
             Actions.STOP_ALARM.toString() -> stopAlarm()
 
             Actions.UPDATE_ALARM_TONE.toString() -> updateAlarmTone()
+
+            Actions.WAKE_UP.toString() -> { /* Wakes up the service from Doze mode */ }
         }
         return super.onStartCommand(intent, flags, startId)
     }
@@ -186,6 +195,7 @@ class TimerService : Service(), KoinComponent {
             _timerState.update { currentState ->
                 currentState.copy(timerRunning = false)
             }
+            alarmManager.cancel(alarmIntent)
             pauseTime = SystemClock.elapsedRealtime()
         } else {
             if (_timerState.value.timerMode == TimerMode.FOCUS) setDoNotDisturb(true)
@@ -195,6 +205,28 @@ class TimerService : Service(), KoinComponent {
             )
             _timerState.update { it.copy(timerRunning = true) }
             if (pauseTime != 0L) pauseDuration += SystemClock.elapsedRealtime() - pauseTime
+
+            val settingsStateNow = _settingsState.value
+            val timerStateNow = _timerState.value
+            val focusTimeNow = if (!timerStateNow.infiniteFocus) settingsStateNow.focusTime else Long.MAX_VALUE
+            val timeRemainingNow = when (timerStateNow.timerMode) {
+                TimerMode.FOCUS -> focusTimeNow - (SystemClock.elapsedRealtime() - (if (startTime == 0L) SystemClock.elapsedRealtime() else startTime) - pauseDuration)
+                TimerMode.SHORT_BREAK -> settingsStateNow.shortBreakTime - (SystemClock.elapsedRealtime() - (if (startTime == 0L) SystemClock.elapsedRealtime() else startTime) - pauseDuration)
+                else -> settingsStateNow.longBreakTime - (SystemClock.elapsedRealtime() - (if (startTime == 0L) SystemClock.elapsedRealtime() else startTime) - pauseDuration)
+            }
+            
+            if (timeRemainingNow > 0 && (!timerStateNow.infiniteFocus || timerStateNow.timerMode != TimerMode.FOCUS)) {
+                val triggerTime = SystemClock.elapsedRealtime() + timeRemainingNow
+                try {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !alarmManager.canScheduleExactAlarms()) {
+                        alarmManager.setAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerTime, alarmIntent)
+                    } else {
+                        alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerTime, alarmIntent)
+                    }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                }
+            }
 
             var iterations = -1
             var notificationUpdateCounter = -1
@@ -395,6 +427,7 @@ class TimerService : Service(), KoinComponent {
     }
 
     private suspend fun resetTimer() {
+        alarmManager.cancel(alarmIntent)
         val settingsState = _settingsState.value
         val timerState = _timerState.value
 
@@ -444,6 +477,7 @@ class TimerService : Service(), KoinComponent {
     }
 
     private suspend fun skipTimer(fromButton: Boolean = false) {
+        alarmManager.cancel(alarmIntent)
         val settingsState = _settingsState.value
         saveTimeToDb()
         updateProgressSegments()
@@ -646,6 +680,6 @@ class TimerService : Service(), KoinComponent {
     }
 
     enum class Actions {
-        TOGGLE, SKIP, RESET, UNDO_RESET, STOP_ALARM, UPDATE_ALARM_TONE
+        TOGGLE, SKIP, RESET, UNDO_RESET, STOP_ALARM, UPDATE_ALARM_TONE, WAKE_UP
     }
 }

--- a/shared/src/androidMain/kotlin/org/nsh07/pomodoro/data/AndroidBackupRestoreManager.kt
+++ b/shared/src/androidMain/kotlin/org/nsh07/pomodoro/data/AndroidBackupRestoreManager.kt
@@ -45,15 +45,16 @@ class AndroidBackupRestoreManager(
     private val context: Context
 ) : BackupRestoreManager {
     override suspend fun performBackup(directoryLocator: FileLocator) {
+        val uri = directoryLocator.uri ?: return
         withContext(Dispatchers.IO) {
             systemDao.checkpoint(SimpleSQLiteQuery("pragma wal_checkpoint(full)"))
 
             val dbName = "app_database"
             val dbFile = context.getDatabasePath(dbName)
 
-            val documentId = DocumentsContract.getTreeDocumentId(directoryLocator.uri)
+            val documentId = DocumentsContract.getTreeDocumentId(uri)
             val parentDocumentUri =
-                DocumentsContract.buildDocumentUriUsingTree(directoryLocator.uri, documentId)
+                DocumentsContract.buildDocumentUriUsingTree(uri, documentId)
 
             val fileUri = DocumentsContract.createDocument(
                 context.contentResolver,
@@ -73,19 +74,19 @@ class AndroidBackupRestoreManager(
     }
 
     override suspend fun performRestore(fileLocator: FileLocator) {
-        if (fileLocator.isNull) return
+        val uri = fileLocator.uri ?: return
         withContext(Dispatchers.IO) {
             database.close()
 
             val dbName = "app_database"
             val dbFile = context.getDatabasePath(dbName)
 
-            if (!dbFile.parentFile!!.exists()) dbFile.parentFile!!.mkdirs()
+            dbFile.parentFile?.let { if (!it.exists()) it.mkdirs() }
 
             File("${dbFile.path}-wal").delete()
             File("${dbFile.path}-shm").delete()
 
-            context.contentResolver.openInputStream(fileLocator.uri!!)?.use { input ->
+            context.contentResolver.openInputStream(uri)?.use { input ->
                 FileOutputStream(dbFile).use { output ->
                     input.copyTo(output)
                 }

--- a/shared/src/androidMain/kotlin/org/nsh07/pomodoro/ui/timerScreen/viewModel/TimerViewModel.kt
+++ b/shared/src/androidMain/kotlin/org/nsh07/pomodoro/ui/timerScreen/viewModel/TimerViewModel.kt
@@ -58,9 +58,10 @@ class TimerViewModel(
 
             // Fills dates between today and lastDate with 0s to ensure continuous history
             if (lastDate != null) {
-                while (ChronoUnit.DAYS.between(lastDate, today) > 0) {
-                    lastDate = lastDate?.plusDays(1)
-                    statRepository.insertStat(Stat(lastDate!!, 0, 0, 0, 0, 0))
+                var currentDate: LocalDate = lastDate
+                while (ChronoUnit.DAYS.between(currentDate, today) > 0) {
+                    currentDate = currentDate.plusDays(1)
+                    statRepository.insertStat(Stat(currentDate, 0, 0, 0, 0, 0))
                 }
             } else {
                 statRepository.insertStat(Stat(today, 0, 0, 0, 0, 0))


### PR DESCRIPTION
This PR fixes several bugs identified in the codebase:
- **Doze Mode Fix:** Uses AlarmManager.setExactAndAllowWhileIdle to wake the device and trigger the timer exactly when expected, preventing the timer from pausing while the screen is off.
- **ANR Fix:** Moves the saveTimeToDb() call in TimerService.onDestroy off the main thread using a coroutine, removing the blocking runBlocking call.
- **NPE Fixes:** Resolves unsafe non-null assertions in AndroidBackupRestoreManager and TimerViewModel to prevent runtime crashes.